### PR TITLE
EWB-2448: Pandapower Translator Example

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
   * Interacting with a network model (e.g. adding and removing objects)
   * Examining connectivity of cores on equipment and terminals
   * Running network traces
+  * Translating a CIM network model into a pandapower model
 
 ### Enhancements
 * None.

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,10 @@ setup(
     install_requires=[
         "zepben.auth==0.10.0b2",
         "zepben.eas==0.9.0b1",
-        "zepben.evolve==0.35.0b7",
-        "zepben.protobuf==0.23.0b1",
-        "zepben.edith==0.3.0b2",
-        "pp-translator==0.7.0b1",
+        "zepben.evolve==0.35.0b9",
+        "zepben.protobuf==0.23.0b5",
+        "zepben.edith==0.3.0b3",
+        "pp-translator==0.7.0b2",
     ],
     extras_require={
         "test": test_deps,

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         "zepben.protobuf==0.23.0b5",
         "zepben.edith==0.3.0b3",
         "pp-translator==0.7.0b2",
+        "numba==0.56.4"
     ],
     extras_require={
         "test": test_deps,

--- a/src/zepben/examples/ieee_13_node_test_feeder.py
+++ b/src/zepben/examples/ieee_13_node_test_feeder.py
@@ -8,108 +8,116 @@ from typing import Tuple
 import numpy
 from zepben.evolve import AcLineSegment, Disconnector, PowerTransformer, TransformerFunctionKind, NetworkService, Terminal, PowerTransformerEnd, EnergyConsumer, \
     PerLengthSequenceImpedance, PhaseCode, EnergyConsumerPhase, SinglePhaseKind, LinearShuntCompensator, ShuntCompensatorInfo, PhaseShuntConnectionKind, Feeder, \
-    LvFeeder
+    LvFeeder, BaseVoltage, EnergySource, Breaker
 
 __all__ = ["network"]
 
 FEET_PER_MILE = 5280
 
+#################
+# BASE VOLTAGES #
+#################
+mv = BaseVoltage(mrid="mv", nominal_voltage=4_160)
+lv = BaseVoltage(mrid="lv", nominal_voltage=480)
 
 ###########################
 # EQUIPMENT AND TERMINALS #
 ###########################
-# Terminal phases are ABC by default
+# Terminal phases are ABC by default. The substation and its equipment is excluded from the model.
+br_650_t1, br_650_t2 = Terminal(mrid="br_650_t1"), Terminal(mrid="br_650_t2")
+br_650 = Breaker(mrid="br_650", terminals=[br_650_t1, br_650_t2], base_voltage=mv)
+
 vr_650_632_t1, vr_650_632_t2 = Terminal(mrid="vr_650_632_t1"), Terminal(mrid="vr_650_632_t2") 
-vr_650_632_e1 = PowerTransformerEnd(mrid="vr_650_632_e1", terminal=vr_650_632_t1)
-vr_650_632_e2 = PowerTransformerEnd(mrid="vr_650_632_e2", terminal=vr_650_632_t2)
+vr_650_632_e1 = PowerTransformerEnd(mrid="vr_650_632_e1", terminal=vr_650_632_t1, rated_u=mv.nominal_voltage)
+vr_650_632_e2 = PowerTransformerEnd(mrid="vr_650_632_e2", terminal=vr_650_632_t2, rated_u=mv.nominal_voltage)
 vr_650_632 = PowerTransformer(mrid="vr_650_632", function=TransformerFunctionKind.voltageRegulator, terminals=[vr_650_632_t1, vr_650_632_t2],
                               power_transformer_ends=[vr_650_632_e1, vr_650_632_e2])
 
 l_632_645_t1, l_632_645_t2 = Terminal(mrid="l_632_645_t1", phases=PhaseCode.BCN), Terminal(mrid="l_632_645_t2", phases=PhaseCode.BCN) 
-l_632_645 = AcLineSegment(mrid="l_632_645", length=500, terminals=[l_632_645_t1, l_632_645_t2])
+l_632_645 = AcLineSegment(mrid="l_632_645", length=500, terminals=[l_632_645_t1, l_632_645_t2], base_voltage=mv)
 
 l_632_633_t1, l_632_633_t2 = Terminal(mrid="l_632_633_t1", phases=PhaseCode.ABCN), Terminal(mrid="l_632_633_t2", phases=PhaseCode.ABCN) 
-l_632_633 = AcLineSegment(mrid="l_632_633", length=500, terminals=[l_632_633_t1, l_632_633_t2])
+l_632_633 = AcLineSegment(mrid="l_632_633", length=500, terminals=[l_632_633_t1, l_632_633_t2], base_voltage=mv)
 
 tx_633_634_t1, tx_633_634_t2 = Terminal(mrid="tx_633_634_t1", phases=PhaseCode.ABCN), Terminal(mrid="tx_633_634_t2", phases=PhaseCode.ABCN) 
-tx_633_634_e1 = PowerTransformerEnd(mrid="tx_633_634_e1", terminal=tx_633_634_t1)
-tx_633_634_e2 = PowerTransformerEnd(mrid="tx_633_634_e2", terminal=tx_633_634_t2)
+tx_633_634_e1 = PowerTransformerEnd(mrid="tx_633_634_e1", terminal=tx_633_634_t1, rated_u=mv.nominal_voltage)
+tx_633_634_e2 = PowerTransformerEnd(mrid="tx_633_634_e2", terminal=tx_633_634_t2, rated_u=lv.nominal_voltage)
 tx_633_634 = PowerTransformer(mrid="tx_633_634", terminals=[tx_633_634_t1, tx_633_634_t2], power_transformer_ends=[tx_633_634_e1, tx_633_634_e2])
 
 l_645_646_t1, l_645_646_t2 = Terminal(mrid="l_645_646_t1", phases=PhaseCode.BCN), Terminal(mrid="l_645_646_t2", phases=PhaseCode.BCN) 
-l_645_646 = AcLineSegment(mrid="l_645_646", length=300, terminals=[l_645_646_t1, l_645_646_t2])
+l_645_646 = AcLineSegment(mrid="l_645_646", length=300, terminals=[l_645_646_t1, l_645_646_t2], base_voltage=mv)
 
 l_650_632_t1, l_650_632_t2 = Terminal(mrid="l_650_632_t1", phases=PhaseCode.ABCN), Terminal(mrid="l_650_632_t2", phases=PhaseCode.ABCN) 
-l_650_632 = AcLineSegment(mrid="l_650_632", length=2000, terminals=[l_650_632_t1, l_650_632_t2])
+l_650_632 = AcLineSegment(mrid="l_650_632", length=2000, terminals=[l_650_632_t1, l_650_632_t2], base_voltage=mv)
 
 l_684_652_t1, l_684_652_t2 = Terminal(mrid="l_684_652_t1", phases=PhaseCode.AN), Terminal(mrid="l_684_652_t2", phases=PhaseCode.AN) 
-l_684_652 = AcLineSegment(mrid="l_684_652", length=800, terminals=[l_684_652_t1, l_684_652_t2])
+l_684_652 = AcLineSegment(mrid="l_684_652", length=800, terminals=[l_684_652_t1, l_684_652_t2], base_voltage=mv)
 
 l_632_671_t1, l_632_671_t2 = Terminal(mrid="l_632_671_t1", phases=PhaseCode.ABCN), Terminal(mrid="l_632_671_t2", phases=PhaseCode.ABCN) 
-l_632_671 = AcLineSegment(mrid="l_632_671", length=2000, terminals=[l_632_671_t1, l_632_671_t2])
+l_632_671 = AcLineSegment(mrid="l_632_671", length=2000, terminals=[l_632_671_t1, l_632_671_t2], base_voltage=mv)
 
 l_671_684_t1, l_671_684_t2 = Terminal(mrid="l_671_684_t1", phases=PhaseCode.ACN), Terminal(mrid="l_671_684_t2", phases=PhaseCode.ACN) 
-l_671_684 = AcLineSegment(mrid="l_671_684", length=300, terminals=[l_671_684_t1, l_671_684_t2])
+l_671_684 = AcLineSegment(mrid="l_671_684", length=300, terminals=[l_671_684_t1, l_671_684_t2], base_voltage=mv)
 
 l_671_680_t1, l_671_680_t2 = Terminal(mrid="l_671_680_t1", phases=PhaseCode.ABCN), Terminal(mrid="l_671_680_t2", phases=PhaseCode.ABCN) 
-l_671_680 = AcLineSegment(mrid="l_671_680", length=1000, terminals=[l_671_680_t1, l_671_680_t2])
+l_671_680 = AcLineSegment(mrid="l_671_680", length=1000, terminals=[l_671_680_t1, l_671_680_t2], base_voltage=mv)
 
 sw_671_692_t1, sw_671_692_t2 = Terminal(mrid="sw_671_692_t1", phases=PhaseCode.ABCN), Terminal(mrid="sw_671_692_t2", phases=PhaseCode.ABCN) 
-sw_671_692 = Disconnector(mrid="sw_671_692", terminals=[sw_671_692_t1, sw_671_692_t2])
+sw_671_692 = Disconnector(mrid="sw_671_692", terminals=[sw_671_692_t1, sw_671_692_t2], base_voltage=mv)
 
 l_684_611_t1, l_684_611_t2 = Terminal(mrid="l_684_611_t1", phases=PhaseCode.CN), Terminal(mrid="l_684_611_t2", phases=PhaseCode.CN) 
-l_684_611 = AcLineSegment(mrid="l_684_611", length=300, terminals=[l_684_611_t1, l_684_611_t2])
+l_684_611 = AcLineSegment(mrid="l_684_611", length=300, terminals=[l_684_611_t1, l_684_611_t2], base_voltage=mv)
 
 l_692_675_t1, l_692_675_t2 = Terminal(mrid="l_692_675_t1", phases=PhaseCode.ABCN), Terminal(mrid="l_692_675_t2", phases=PhaseCode.ABCN) 
-l_692_675 = AcLineSegment(mrid="l_692_675", length=500, terminals=[l_692_675_t1, l_692_675_t2])
+l_692_675 = AcLineSegment(mrid="l_692_675", length=500, terminals=[l_692_675_t1, l_692_675_t2], base_voltage=mv)
 
 ec_634_t = Terminal(mrid="ec_634_t", phases=PhaseCode.ABCN)
 ec_634_pha = EnergyConsumerPhase(mrid="ec_634_pha", phase=SinglePhaseKind.A, p_fixed=160000, q_fixed=110000)
 ec_634_phb = EnergyConsumerPhase(mrid="ec_634_phb", phase=SinglePhaseKind.B, p_fixed=120000, q_fixed=90000)
 ec_634_phc = EnergyConsumerPhase(mrid="ec_634_phc", phase=SinglePhaseKind.C, p_fixed=120000, q_fixed=90000)
-ec_634 = EnergyConsumer(mrid="ec_634", terminals=[ec_634_t], energy_consumer_phases=[ec_634_pha, ec_634_phb, ec_634_phc])
+ec_634 = EnergyConsumer(mrid="ec_634", terminals=[ec_634_t], energy_consumer_phases=[ec_634_pha, ec_634_phb, ec_634_phc], base_voltage=lv)
 
 ec_645_t = Terminal(mrid="ec_645_t", phases=PhaseCode.ABCN)
 ec_645_pha = EnergyConsumerPhase(mrid="ec_645_pha", phase=SinglePhaseKind.A, p_fixed=0, q_fixed=0)
 ec_645_phb = EnergyConsumerPhase(mrid="ec_645_phb", phase=SinglePhaseKind.B, p_fixed=170000, q_fixed=125000)
 ec_645_phc = EnergyConsumerPhase(mrid="ec_645_phc", phase=SinglePhaseKind.C, p_fixed=0, q_fixed=0)
-ec_645 = EnergyConsumer(mrid="ec_645", terminals=[ec_645_t], energy_consumer_phases=[ec_645_pha, ec_645_phb, ec_645_phc])
+ec_645 = EnergyConsumer(mrid="ec_645", terminals=[ec_645_t], energy_consumer_phases=[ec_645_pha, ec_645_phb, ec_645_phc], base_voltage=mv)
 
 ec_646_t = Terminal(mrid="ec_646_t", phases=PhaseCode.ABC)
 ec_646_pha = EnergyConsumerPhase(mrid="ec_646_pha", phase=SinglePhaseKind.A, p=0, q=0)
 ec_646_phb = EnergyConsumerPhase(mrid="ec_646_phb", phase=SinglePhaseKind.B, p=230000, q=132000)
 ec_646_phc = EnergyConsumerPhase(mrid="ec_646_phc", phase=SinglePhaseKind.C, p=0, q=0)
-ec_646 = EnergyConsumer(mrid="ec_646", terminals=[ec_646_t], energy_consumer_phases=[ec_646_pha, ec_646_phb, ec_646_phc])
+ec_646 = EnergyConsumer(mrid="ec_646", terminals=[ec_646_t], energy_consumer_phases=[ec_646_pha, ec_646_phb, ec_646_phc], base_voltage=mv)
 
 ec_652_t = Terminal(mrid="ec_652_t", phases=PhaseCode.ABCN)
 ec_652_pha = EnergyConsumerPhase(mrid="ec_652_pha", phase=SinglePhaseKind.A, p=128000, q=86000)
 ec_652_phb = EnergyConsumerPhase(mrid="ec_652_phb", phase=SinglePhaseKind.B, p=0, q=0)
 ec_652_phc = EnergyConsumerPhase(mrid="ec_652_phc", phase=SinglePhaseKind.C, p=0, q=0)
-ec_652 = EnergyConsumer(mrid="ec_652", terminals=[ec_652_t], energy_consumer_phases=[ec_652_pha, ec_652_phb, ec_652_phc])
+ec_652 = EnergyConsumer(mrid="ec_652", terminals=[ec_652_t], energy_consumer_phases=[ec_652_pha, ec_652_phb, ec_652_phc], base_voltage=mv)
 
 ec_671_t = Terminal(mrid="ec_671_t", phases=PhaseCode.ABC)
 ec_671_pha = EnergyConsumerPhase(mrid="ec_671_pha", phase=SinglePhaseKind.A, p_fixed=385000, q_fixed=220000)
 ec_671_phb = EnergyConsumerPhase(mrid="ec_671_phb", phase=SinglePhaseKind.B, p_fixed=385000, q_fixed=220000)
 ec_671_phc = EnergyConsumerPhase(mrid="ec_671_phc", phase=SinglePhaseKind.C, p_fixed=385000, q_fixed=220000)
-ec_671 = EnergyConsumer(mrid="ec_671", terminals=[ec_671_t], energy_consumer_phases=[ec_671_pha, ec_671_phb, ec_671_phc])
+ec_671 = EnergyConsumer(mrid="ec_671", terminals=[ec_671_t], energy_consumer_phases=[ec_671_pha, ec_671_phb, ec_671_phc], base_voltage=mv)
 
 ec_675_t = Terminal(mrid="ec_675_t", phases=PhaseCode.ABCN)
 ec_675_pha = EnergyConsumerPhase(mrid="ec_675_pha", phase=SinglePhaseKind.A, p_fixed=485000, q_fixed=190000)
 ec_675_phb = EnergyConsumerPhase(mrid="ec_675_phb", phase=SinglePhaseKind.B, p_fixed=68000, q_fixed=60000)
 ec_675_phc = EnergyConsumerPhase(mrid="ec_675_phc", phase=SinglePhaseKind.C, p_fixed=290000, q_fixed=212000)
-ec_675 = EnergyConsumer(mrid="ec_675", terminals=[ec_675_t], energy_consumer_phases=[ec_675_pha, ec_675_phb, ec_675_phc])
+ec_675 = EnergyConsumer(mrid="ec_675", terminals=[ec_675_t], energy_consumer_phases=[ec_675_pha, ec_675_phb, ec_675_phc], base_voltage=mv)
 
 ec_692_t = Terminal(mrid="ec_692_t", phases=PhaseCode.ABC)
 ec_692_pha = EnergyConsumerPhase(mrid="ec_692_pha", phase=SinglePhaseKind.A, p=0, q=0)
 ec_692_phb = EnergyConsumerPhase(mrid="ec_692_phb", phase=SinglePhaseKind.B, p=0, q=0)
 ec_692_phc = EnergyConsumerPhase(mrid="ec_692_phc", phase=SinglePhaseKind.C, p=170000, q=151000)
-ec_692 = EnergyConsumer(mrid="ec_692", terminals=[ec_692_t], energy_consumer_phases=[ec_692_pha, ec_692_phb, ec_692_phc])
+ec_692 = EnergyConsumer(mrid="ec_692", terminals=[ec_692_t], energy_consumer_phases=[ec_692_pha, ec_692_phb, ec_692_phc], base_voltage=mv)
 
 ec_611_t = Terminal(mrid="ec_611_t", phases=PhaseCode.ABCN)
 ec_611_pha = EnergyConsumerPhase(mrid="ec_611_pha", phase=SinglePhaseKind.A, p=0, q=0)
 ec_611_phb = EnergyConsumerPhase(mrid="ec_611_phb", phase=SinglePhaseKind.B, p=0, q=0)
 ec_611_phc = EnergyConsumerPhase(mrid="ec_611_phc", phase=SinglePhaseKind.C, p=170000, q=80000)
-ec_611 = EnergyConsumer(mrid="ec_611", terminals=[ec_611_t], energy_consumer_phases=[ec_611_pha, ec_611_phb, ec_611_phc])
+ec_611 = EnergyConsumer(mrid="ec_611", terminals=[ec_611_t], energy_consumer_phases=[ec_611_pha, ec_611_phb, ec_611_phc], base_voltage=mv)
 
 # Distributed load on line 632-671 is unmodelled.
 
@@ -151,25 +159,25 @@ l_692_675.per_length_sequence_impedance = plsi_606
 ##############
 # CONTAINERS #
 ##############
-hv_fdr = Feeder(mrid="hv_fdr", normal_head_terminal=vr_650_632_t2)
+hv_fdr = Feeder(mrid="hv_fdr", normal_head_terminal=br_650_t2)
 lv_fdr = LvFeeder(mrid="lv_fdr", normal_head_terminal=tx_633_634_t2)
 
 ##########################
 # BUILDING NETWORK MODEL #
 ##########################
 network = NetworkService()
-for io in [vr_650_632, vr_650_632_t1, vr_650_632_t2, vr_650_632_e1, vr_650_632_e2, l_632_645, l_632_645_t1, l_632_645_t2, l_632_633, l_632_633_t1, l_632_633_t2,
-           tx_633_634, tx_633_634_t1, tx_633_634_t2, tx_633_634_e1, tx_633_634_e2, l_645_646, l_645_646_t1, l_645_646_t2, l_650_632, l_650_632_t1, l_650_632_t2,
-           l_684_652, l_684_652_t1, l_684_652_t2, l_632_671, l_632_671_t1, l_632_671_t2, l_671_684, l_671_684_t1, l_671_684_t2, l_671_680, l_671_680_t1,
-           l_671_680_t2, sw_671_692, sw_671_692_t1, sw_671_692_t2, l_684_611, l_684_611_t1, l_684_611_t2, l_692_675, l_692_675_t1, l_692_675_t2, ec_634_t,
-           ec_634_pha, ec_634_phb, ec_634_phc, ec_634, ec_645_t, ec_645_pha, ec_645_phb, ec_645_phc, ec_645, ec_646_t, ec_646_pha, ec_646_phb, ec_646_phc,
-           ec_646, ec_652_t, ec_652_pha, ec_652_phb, ec_652_phc, ec_652, ec_671_t, ec_671_pha, ec_671_phb, ec_671_phc, ec_671, ec_675_t, ec_675_pha, ec_675_phb,
-           ec_675_phc, ec_675, ec_692_t, ec_692_pha, ec_692_phb, ec_692_phc, ec_692, ec_611_t, ec_611_pha, ec_611_phb, ec_611_phc, ec_611, lsc_675_t1,
-           lsc_675_t2, lsc_675_info, lsc_675, lsc_611_t1, lsc_611_t2, lsc_611_info, lsc_611, plsi_601, plsi_602, plsi_603, plsi_604, plsi_605, plsi_606,
-           plsi_607, hv_fdr, lv_fdr]:
+for io in [br_650, br_650_t1, br_650_t2, vr_650_632, vr_650_632_t1, vr_650_632_t2, vr_650_632_e1, vr_650_632_e2, l_632_645, l_632_645_t1, l_632_645_t2,
+           l_632_633, l_632_633_t1, l_632_633_t2, tx_633_634, tx_633_634_t1, tx_633_634_t2, tx_633_634_e1, tx_633_634_e2, l_645_646, l_645_646_t1, l_645_646_t2,
+           l_650_632, l_650_632_t1, l_650_632_t2, l_684_652, l_684_652_t1, l_684_652_t2, l_632_671, l_632_671_t1, l_632_671_t2, l_671_684, l_671_684_t1,
+           l_671_684_t2, l_671_680, l_671_680_t1, l_671_680_t2, sw_671_692, sw_671_692_t1, sw_671_692_t2, l_684_611, l_684_611_t1, l_684_611_t2, l_692_675,
+           l_692_675_t1, l_692_675_t2, ec_634_t, ec_634_pha, ec_634_phb, ec_634_phc, ec_634, ec_645_t, ec_645_pha, ec_645_phb, ec_645_phc, ec_645, ec_646_t,
+           ec_646_pha, ec_646_phb, ec_646_phc, ec_646, ec_652_t, ec_652_pha, ec_652_phb, ec_652_phc, ec_652, ec_671_t, ec_671_pha, ec_671_phb, ec_671_phc,
+           ec_671, ec_675_t, ec_675_pha, ec_675_phb, ec_675_phc, ec_675, ec_692_t, ec_692_pha, ec_692_phb, ec_692_phc, ec_692, ec_611_t, ec_611_pha, ec_611_phb,
+           ec_611_phc, ec_611, lsc_675_t1, lsc_675_t2, lsc_675_info, lsc_675, lsc_611_t1, lsc_611_t2, lsc_611_info, lsc_611, plsi_601, plsi_602, plsi_603,
+           plsi_604, plsi_605, plsi_606, plsi_607, hv_fdr, lv_fdr, mv, lv]:
     network.add(io)
 
-# Complete 630-632 regulator + line
+# Complete 650-632 regulator + line
 network.connect_terminals(vr_650_632_t2, l_650_632_t1)
 
 # Node 611
@@ -193,6 +201,9 @@ network.connect_terminals(l_632_645_t2, ec_645_t)
 
 # Node 646
 network.connect_terminals(l_645_646_t2, ec_646_t)
+
+# Node 650
+network.connect_terminals(br_650_t2, vr_650_632_t1)
 
 # Node 652
 network.connect_terminals(l_684_652_t2, ec_652_t)

--- a/src/zepben/examples/ieee_13_node_test_feeder.py
+++ b/src/zepben/examples/ieee_13_node_test_feeder.py
@@ -122,13 +122,13 @@ ec_611 = EnergyConsumer(mrid="ec_611", terminals=[ec_611_t], energy_consumer_pha
 
 # Distributed load on line 632-671 is unmodelled.
 
-lsc_675_t1, lsc_675_t2 = Terminal(mrid="lsc_675_t1", phases=PhaseCode.ABCN), Terminal(mrid="lsc_675_t2", phases=PhaseCode.ABCN) 
+lsc_675_t= Terminal(mrid="lsc_675_t1", phases=PhaseCode.ABCN)
 lsc_675_info = ShuntCompensatorInfo(mrid="lsc_675_info", rated_voltage=4160, rated_current=48.077, rated_reactive_power=200000)
-lsc_675 = LinearShuntCompensator(mrid="lsc_675", terminals=[lsc_675_t1, lsc_675_t2], asset_info=lsc_675_info)
+lsc_675 = LinearShuntCompensator(mrid="lsc_675", terminals=[lsc_675_t], asset_info=lsc_675_info)
 
-lsc_611_t1, lsc_611_t2 = Terminal(mrid="lsc_611_t1", phases=PhaseCode.CN), Terminal(mrid="lsc_611_t2", phases=PhaseCode.CN) 
+lsc_611_t = Terminal(mrid="lsc_611_t1", phases=PhaseCode.CN)
 lsc_611_info = ShuntCompensatorInfo(mrid="lsc_611_info", rated_voltage=4160, rated_current=24.048, rated_reactive_power=100000)
-lsc_611 = LinearShuntCompensator(mrid="lsc_611", terminals=[lsc_611_t1, lsc_611_t2], asset_info=lsc_611_info)
+lsc_611 = LinearShuntCompensator(mrid="lsc_611", terminals=[lsc_611_t], asset_info=lsc_611_info)
 
 ###########################
 # SETTING LINE IMPEDANCES #
@@ -174,16 +174,16 @@ for io in [br_650, br_650_t1, br_650_t2, vr_650_632, vr_650_632_t1, vr_650_632_t
            l_692_675_t1, l_692_675_t2, ec_634_t, ec_634_pha, ec_634_phb, ec_634_phc, ec_634, ec_645_t, ec_645_pha, ec_645_phb, ec_645_phc, ec_645, ec_646_t,
            ec_646_pha, ec_646_phb, ec_646_phc, ec_646, ec_652_t, ec_652_pha, ec_652_phb, ec_652_phc, ec_652, ec_671_t, ec_671_pha, ec_671_phb, ec_671_phc,
            ec_671, ec_675_t, ec_675_pha, ec_675_phb, ec_675_phc, ec_675, ec_692_t, ec_692_pha, ec_692_phb, ec_692_phc, ec_692, ec_611_t, ec_611_pha, ec_611_phb,
-           ec_611_phc, ec_611, lsc_675_t1, lsc_675_t2, lsc_675_info, lsc_675, lsc_611_t1, lsc_611_t2, lsc_611_info, lsc_611, plsi_601, plsi_602, plsi_603,
-           plsi_604, plsi_605, plsi_606, plsi_607, hv_fdr, lv_fdr, mv, lv]:
+           ec_611_phc, ec_611, lsc_675_t, lsc_675_info, lsc_675, lsc_611_t, lsc_611_info, lsc_611, plsi_601, plsi_602, plsi_603, plsi_604, plsi_605, plsi_606,
+           plsi_607, hv_fdr, lv_fdr, mv, lv]:
     network.add(io)
 
 # Complete 650-632 regulator + line
 network.connect_terminals(vr_650_632_t2, l_650_632_t1)
 
 # Node 611
-network.connect_terminals(l_684_611_t2, lsc_611_t1)
-network.connect_terminals(lsc_611_t2, ec_611_t)
+network.connect_terminals(l_684_611_t2, lsc_611_t)
+network.connect_terminals(l_684_611_t2, ec_611_t)
 
 # Node 632
 network.connect_terminals(l_650_632_t2, l_632_633_t1)
@@ -216,8 +216,8 @@ network.connect_terminals(l_632_671_t2, sw_671_692_t1)
 network.connect_terminals(l_632_671_t2, ec_671_t)
 
 # Node 675
-network.connect_terminals(l_692_675_t2, lsc_675_t1)
-network.connect_terminals(lsc_675_t2, ec_675_t)
+network.connect_terminals(l_692_675_t2, lsc_675_t)
+network.connect_terminals(l_692_675_t2, ec_675_t)
 
 # Node 684
 network.connect_terminals(l_671_684_t2, l_684_611_t1)

--- a/src/zepben/examples/ieee_13_node_test_feeder.py
+++ b/src/zepben/examples/ieee_13_node_test_feeder.py
@@ -13,6 +13,7 @@ from zepben.evolve import AcLineSegment, Disconnector, PowerTransformer, Transfo
 __all__ = ["network"]
 
 FEET_PER_MILE = 5280
+METRES_PER_FOOT = 0.3048
 
 #################
 # BASE VOLTAGES #
@@ -34,10 +35,10 @@ vr_650_632 = PowerTransformer(mrid="vr_650_632", function=TransformerFunctionKin
                               power_transformer_ends=[vr_650_632_e1, vr_650_632_e2])
 
 l_632_645_t1, l_632_645_t2 = Terminal(mrid="l_632_645_t1", phases=PhaseCode.BCN), Terminal(mrid="l_632_645_t2", phases=PhaseCode.BCN) 
-l_632_645 = AcLineSegment(mrid="l_632_645", length=500, terminals=[l_632_645_t1, l_632_645_t2], base_voltage=mv)
+l_632_645 = AcLineSegment(mrid="l_632_645", length=500 * METRES_PER_FOOT, terminals=[l_632_645_t1, l_632_645_t2], base_voltage=mv)
 
 l_632_633_t1, l_632_633_t2 = Terminal(mrid="l_632_633_t1", phases=PhaseCode.ABCN), Terminal(mrid="l_632_633_t2", phases=PhaseCode.ABCN) 
-l_632_633 = AcLineSegment(mrid="l_632_633", length=500, terminals=[l_632_633_t1, l_632_633_t2], base_voltage=mv)
+l_632_633 = AcLineSegment(mrid="l_632_633", length=500 * METRES_PER_FOOT, terminals=[l_632_633_t1, l_632_633_t2], base_voltage=mv)
 
 tx_633_634_t1, tx_633_634_t2 = Terminal(mrid="tx_633_634_t1", phases=PhaseCode.ABCN), Terminal(mrid="tx_633_634_t2", phases=PhaseCode.ABCN) 
 tx_633_634_e1 = PowerTransformerEnd(mrid="tx_633_634_e1", terminal=tx_633_634_t1, rated_u=mv.nominal_voltage)
@@ -45,31 +46,31 @@ tx_633_634_e2 = PowerTransformerEnd(mrid="tx_633_634_e2", terminal=tx_633_634_t2
 tx_633_634 = PowerTransformer(mrid="tx_633_634", terminals=[tx_633_634_t1, tx_633_634_t2], power_transformer_ends=[tx_633_634_e1, tx_633_634_e2])
 
 l_645_646_t1, l_645_646_t2 = Terminal(mrid="l_645_646_t1", phases=PhaseCode.BCN), Terminal(mrid="l_645_646_t2", phases=PhaseCode.BCN) 
-l_645_646 = AcLineSegment(mrid="l_645_646", length=300, terminals=[l_645_646_t1, l_645_646_t2], base_voltage=mv)
+l_645_646 = AcLineSegment(mrid="l_645_646", length=300 * METRES_PER_FOOT, terminals=[l_645_646_t1, l_645_646_t2], base_voltage=mv)
 
 l_650_632_t1, l_650_632_t2 = Terminal(mrid="l_650_632_t1", phases=PhaseCode.ABCN), Terminal(mrid="l_650_632_t2", phases=PhaseCode.ABCN) 
-l_650_632 = AcLineSegment(mrid="l_650_632", length=2000, terminals=[l_650_632_t1, l_650_632_t2], base_voltage=mv)
+l_650_632 = AcLineSegment(mrid="l_650_632", length=2000 * METRES_PER_FOOT, terminals=[l_650_632_t1, l_650_632_t2], base_voltage=mv)
 
 l_684_652_t1, l_684_652_t2 = Terminal(mrid="l_684_652_t1", phases=PhaseCode.AN), Terminal(mrid="l_684_652_t2", phases=PhaseCode.AN) 
-l_684_652 = AcLineSegment(mrid="l_684_652", length=800, terminals=[l_684_652_t1, l_684_652_t2], base_voltage=mv)
+l_684_652 = AcLineSegment(mrid="l_684_652", length=800 * METRES_PER_FOOT, terminals=[l_684_652_t1, l_684_652_t2], base_voltage=mv)
 
 l_632_671_t1, l_632_671_t2 = Terminal(mrid="l_632_671_t1", phases=PhaseCode.ABCN), Terminal(mrid="l_632_671_t2", phases=PhaseCode.ABCN) 
-l_632_671 = AcLineSegment(mrid="l_632_671", length=2000, terminals=[l_632_671_t1, l_632_671_t2], base_voltage=mv)
+l_632_671 = AcLineSegment(mrid="l_632_671", length=2000 * METRES_PER_FOOT, terminals=[l_632_671_t1, l_632_671_t2], base_voltage=mv)
 
 l_671_684_t1, l_671_684_t2 = Terminal(mrid="l_671_684_t1", phases=PhaseCode.ACN), Terminal(mrid="l_671_684_t2", phases=PhaseCode.ACN) 
-l_671_684 = AcLineSegment(mrid="l_671_684", length=300, terminals=[l_671_684_t1, l_671_684_t2], base_voltage=mv)
+l_671_684 = AcLineSegment(mrid="l_671_684", length=300 * METRES_PER_FOOT, terminals=[l_671_684_t1, l_671_684_t2], base_voltage=mv)
 
 l_671_680_t1, l_671_680_t2 = Terminal(mrid="l_671_680_t1", phases=PhaseCode.ABCN), Terminal(mrid="l_671_680_t2", phases=PhaseCode.ABCN) 
-l_671_680 = AcLineSegment(mrid="l_671_680", length=1000, terminals=[l_671_680_t1, l_671_680_t2], base_voltage=mv)
+l_671_680 = AcLineSegment(mrid="l_671_680", length=1000 * METRES_PER_FOOT, terminals=[l_671_680_t1, l_671_680_t2], base_voltage=mv)
 
 sw_671_692_t1, sw_671_692_t2 = Terminal(mrid="sw_671_692_t1", phases=PhaseCode.ABCN), Terminal(mrid="sw_671_692_t2", phases=PhaseCode.ABCN) 
 sw_671_692 = Disconnector(mrid="sw_671_692", terminals=[sw_671_692_t1, sw_671_692_t2], base_voltage=mv)
 
 l_684_611_t1, l_684_611_t2 = Terminal(mrid="l_684_611_t1", phases=PhaseCode.CN), Terminal(mrid="l_684_611_t2", phases=PhaseCode.CN) 
-l_684_611 = AcLineSegment(mrid="l_684_611", length=300, terminals=[l_684_611_t1, l_684_611_t2], base_voltage=mv)
+l_684_611 = AcLineSegment(mrid="l_684_611", length=300 * METRES_PER_FOOT, terminals=[l_684_611_t1, l_684_611_t2], base_voltage=mv)
 
 l_692_675_t1, l_692_675_t2 = Terminal(mrid="l_692_675_t1", phases=PhaseCode.ABCN), Terminal(mrid="l_692_675_t2", phases=PhaseCode.ABCN) 
-l_692_675 = AcLineSegment(mrid="l_692_675", length=500, terminals=[l_692_675_t1, l_692_675_t2], base_voltage=mv)
+l_692_675 = AcLineSegment(mrid="l_692_675", length=500 * METRES_PER_FOOT, terminals=[l_692_675_t1, l_692_675_t2], base_voltage=mv)
 
 ec_634_t = Terminal(mrid="ec_634_t", phases=PhaseCode.ABCN)
 ec_634_pha = EnergyConsumerPhase(mrid="ec_634_pha", phase=SinglePhaseKind.A, p_fixed=160000, q_fixed=110000)
@@ -133,8 +134,8 @@ lsc_611 = LinearShuntCompensator(mrid="lsc_611", terminals=[lsc_611_t1, lsc_611_
 # SETTING LINE IMPEDANCES #
 ###########################
 def plsi_from_z_per_mile(mrid: str, *impedances: Tuple[float, float]):
-    r_per_foot, x_per_foot = numpy.mean(impedances, axis=0) / FEET_PER_MILE
-    return PerLengthSequenceImpedance(mrid=mrid, r=r_per_foot, x=x_per_foot)
+    r_per_metre, x_per_metre = numpy.mean(impedances, axis=0) / (METRES_PER_FOOT * FEET_PER_MILE)
+    return PerLengthSequenceImpedance(mrid=mrid, r=r_per_metre, x=x_per_metre)
 
 
 plsi_601 = plsi_from_z_per_mile("plsi_601", (0.3465, 1.0179), (0.3375, 1.0478), (0.3414, 1.0348))

--- a/src/zepben/examples/tracing.py
+++ b/src/zepben/examples/tracing.py
@@ -11,9 +11,9 @@ import asyncio
 from zepben.evolve import Switch, connected_equipment_trace, ConductingEquipmentStep, connected_equipment_breadth_trace, \
     normal_connected_equipment_trace, current_connected_equipment_trace, connectivity_trace, ConnectivityResult, connected_equipment, \
     connectivity_breadth_trace, SinglePhaseKind, normal_connectivity_trace, current_connectivity_trace, phase_trace, PhaseCode, PhaseStep, normal_phase_trace, \
-    PowerTransformer, current_phase_trace, assign_equipment_to_feeders, Feeder, LvFeeder, assign_equipment_to_lv_feeders, set_direction, Terminal, \
+    current_phase_trace, assign_equipment_to_feeders, Feeder, LvFeeder, assign_equipment_to_lv_feeders, set_direction, Terminal, \
     normal_limited_connected_equipment_trace, AcLineSegment, current_limited_connected_equipment_trace, FeederDirection, remove_direction, \
-    normal_downstream_trace, current_downstream_trace, TreeNode
+    normal_downstream_trace, current_downstream_trace, TreeNode, Breaker
 
 from zepben.evolve.services.network.tracing.phases import phase_step
 from zepben.evolve.services.network.tracing.tracing import normal_upstream_trace, current_upstream_trace, normal_downstream_tree, current_downstream_tree
@@ -21,7 +21,7 @@ from zepben.evolve.services.network.tracing.tracing import normal_upstream_trace
 # For the purposes of this example, we will use the IEEE 13 node feeder.
 from zepben.examples.ieee_13_node_test_feeder import network
 
-regulator = network.get("vr_650_632", PowerTransformer)
+feeder_head = network.get("br_650", Breaker)
 switch = network.get("sw_671_692", Switch)
 hv_feeder = network.get("hv_fdr", Feeder)
 lv_feeder = network.get("lv_fdr", LvFeeder)
@@ -46,7 +46,7 @@ async def equipment_traces():
     print_heading("EQUIPMENT TRACING")
 
     # noinspection PyArgumentList
-    start_item = ConductingEquipmentStep(conducting_equipment=regulator)
+    start_item = ConductingEquipmentStep(conducting_equipment=feeder_head)
     visited = set()
 
     async def print_step(ces: ConductingEquipmentStep, _):
@@ -100,7 +100,7 @@ async def connectivity_traces():
     # The tracker ensures that each equipment appears at most once as a destination in a connectivity.
     print_heading("CONNECTIVITY TRACING")
 
-    start_item = connected_equipment(regulator)[0]
+    start_item = connected_equipment(feeder_head)[0]
     visited = set()
 
     async def print_connectivity(cr: ConnectivityResult, _: bool):
@@ -185,7 +185,7 @@ async def phase_traces():
     # Phase traces account for which phases each terminal supports.
     print_heading("PHASE TRACING")
 
-    feeder_head_phase_step = phase_step.start_at(regulator, PhaseCode.ABCN)
+    feeder_head_phase_step = phase_step.start_at(feeder_head, PhaseCode.ABCN)
     switch_phase_step = phase_step.start_at(switch, PhaseCode.ABCN)
     visited = set()
 
@@ -353,12 +353,12 @@ async def trees():
     print()
 
     print("Normal Downstream Tree:")
-    ndt = await normal_downstream_tree().run(regulator)
+    ndt = await normal_downstream_tree().run(feeder_head)
     print_tree(ndt)
     print()
 
     print("Current Downstream Tree:")
-    cdt = await current_downstream_tree().run(regulator)
+    cdt = await current_downstream_tree().run(feeder_head)
     print_tree(cdt)
     print()
 

--- a/src/zepben/examples/translating_to_pandapower_model.py
+++ b/src/zepben/examples/translating_to_pandapower_model.py
@@ -5,6 +5,7 @@
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 import asyncio
 import logging
+import pandapower as pp
 
 from pp_creators.basic_creator import BasicPandaPowerNetworkCreator
 from zepben.evolve import set_direction, NetworkService, Terminal, EnergySource
@@ -49,6 +50,35 @@ async def main():
 
     print("line_geodata table:")
     print(result.network["line_geodata"])
+    print()
+
+    print("Running load flow study...", end="")
+    pp.runpp(result.network)
+    print("done.")
+    print()
+
+    print(result.network)
+    print()
+
+    print("res_bus table:")
+    print(result.network["res_bus"])
+    print()
+
+    print("res_line table:")
+    print(result.network["res_line"])
+    print()
+
+    print("res_trafo table:")
+    print(result.network["res_trafo"])
+    print()
+
+    print("res_ext_grid table:")
+    print(result.network["res_ext_grid"])
+    print()
+
+    print("res_load table:")
+    print(result.network["res_load"])
+    print()
 
 
 def add_energy_source(network: NetworkService, connect_to_terminal: Terminal):

--- a/src/zepben/examples/translating_to_pandapower_model.py
+++ b/src/zepben/examples/translating_to_pandapower_model.py
@@ -17,13 +17,22 @@ logger = logging.getLogger(__name__)
 async def main():
     add_energy_source(network, network["br_650_t1"])
     await set_direction().run(network)
-    result = await BasicPandaPowerNetworkCreator(logger=logger).create(network)
+    bbn_creator = BasicPandaPowerNetworkCreator(
+        logger=logger,
+        ec_load_provider=lambda ec: (5000, 0)  # Model each energy consumer with a 5kW nonreactive load
+    )
+    result = await bbn_creator.create(network)
+
     print(f"Translation successful: {result.was_successful}")
     print(result.network)
     print()
 
     print("bus table:")
     print(result.network["bus"])
+    print()
+
+    print("load table:")
+    print(result.network["load"])
     print()
 
     print("ext_grid table:")

--- a/src/zepben/examples/translating_to_pandapower_model.py
+++ b/src/zepben/examples/translating_to_pandapower_model.py
@@ -7,14 +7,48 @@ import asyncio
 import logging
 
 from pp_creators.basic_creator import BasicPandaPowerNetworkCreator
+from zepben.evolve import set_direction, NetworkService, Terminal, EnergySource
+
 from zepben.examples.ieee_13_node_test_feeder import network
 
 logger = logging.getLogger(__name__)
 
 
 async def main():
+    add_energy_source(network, network["br_650_t1"])
+    await set_direction().run(network)
     result = await BasicPandaPowerNetworkCreator(logger=logger).create(network)
     print(f"Translation successful: {result.was_successful}")
+    print(result.network)
+    print()
+
+    print("bus table:")
+    print(result.network["bus"])
+    print()
+
+    print("ext_grid table:")
+    print(result.network["ext_grid"])
+    print()
+
+    print("line table:")
+    print(result.network["line"])
+    print()
+
+    print("trafo table:")
+    print(result.network["trafo"])
+    print()
+
+    print("line_geodata table:")
+    print(result.network["line_geodata"])
+
+
+def add_energy_source(network: NetworkService, connect_to_terminal: Terminal):
+    bv = connect_to_terminal.conducting_equipment.base_voltage
+    es_t = Terminal(phases=connect_to_terminal.phases)
+    es = EnergySource(terminals=[es_t], base_voltage=bv)
+    network.add(es_t)
+    network.add(es)
+    network.connect_terminals(es_t, connect_to_terminal)
 
 
 if __name__ == "__main__":

--- a/src/zepben/examples/translating_to_pandapower_model.py
+++ b/src/zepben/examples/translating_to_pandapower_model.py
@@ -1,0 +1,21 @@
+#  Copyright 2023 Zeppelin Bend Pty Ltd
+#
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+import asyncio
+import logging
+
+from pp_creators.basic_creator import BasicPandaPowerNetworkCreator
+from zepben.examples.ieee_13_node_test_feeder import network
+
+logger = logging.getLogger(__name__)
+
+
+async def main():
+    result = await BasicPandaPowerNetworkCreator(logger=logger).create(network)
+    print(f"Translation successful: {result.was_successful}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
# Description

Adds an example of a node breaker network model (of the 13 node test feeder) being translated into a Pandapower model.

# Associated tasks:

Tasks blocking this one:
- [x] Merge https://github.com/zepben/evolve-sdk-python/pull/123
- [x] Merge https://github.com/zepben/edith-sdk/pull/4
- [x] Merge https://github.com/zepben/pp-translator/pull/20

Tasks this is blocking:
- None

# Checklist:

- [x] I have performed a self review of my own code.
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary. (No tests needed for example code
- [x] I have updated the changelog.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
