### PR TITLE
[DEV-110] Specify default landing page

### DIFF
--- a/docs/docs/network_service_interactions.mdx
+++ b/docs/docs/network_service_interactions.mdx
@@ -1,6 +1,7 @@
 ---
 id: examples-network-service-interactions
 title: Interacting With a Network Model
+slug: /
 ---
 
 A `NetworkService` is a mutable node breaker network model that implements a subset of IEC61968 and IEC61970 CIM classes.


### PR DESCRIPTION
# Description

Noticed this issue as part of deploying the site. If you run the current version on master and navigate to http://localhost:3000/evolve/docs/ewb-sdk-examples-python you will notice that its a blank page, then when you click `next` on the toolbar it will suddenly show the sidebar and allow navigation between documents. This is because there is no default `index.md` on the root of the docs folder. In the absence of such a thing, you can use font matter to specify the root file. This PR does that, if you try the above steps again on this branch you will find that it will automatically navigate to the first page.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [ ] ~I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
- [ ] ~I have commented my code in any hard-to-understand or hacky areas.~
- [ ] ~I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).
      
### Documentation
- [ ] ~I have updated the changelog.~
- [ ] I have updated any documentation required for these changes.

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.